### PR TITLE
[#91] Add Voice Over gesture support to edit, copy and delete token from collection

### DIFF
--- a/TwoFAS/TwoFAS/Common/LabelRenderer.swift
+++ b/TwoFAS/TwoFAS/Common/LabelRenderer.swift
@@ -84,14 +84,16 @@ final class LabelRenderer: UIView {
         updateAccessibility()
     }
     
-    func setText(_ text: String) {
+    func setText(_ text: String, ignoreVocalization: Bool = true) {
         var newText = text.uppercased()
         if newText.count > 2 {
             newText = newText[0...2]
         }
         titleLabel.text = newText
         
-        accessibilityText = text
+        if !ignoreVocalization {
+            accessibilityText = text
+        }
         updateAccessibility()
     }
     

--- a/TwoFAS/TwoFAS/Root/Modules/Tokens/View/Subviews/Cell/Components/TokensLogo.swift
+++ b/TwoFAS/TwoFAS/Root/Modules/Tokens/View/Subviews/Cell/Components/TokensLogo.swift
@@ -41,7 +41,6 @@ final class TokensLogo: UIView {
         imageView.pinToParent()
         setContentHuggingPriority(.defaultHigh + 2, for: .horizontal)
         setContentHuggingPriority(.defaultLow - 2, for: .vertical)
-        
         addSubview(labelRenderer)
         labelRenderer.pinToParentCenter()
     }
@@ -57,6 +56,7 @@ final class TokensLogo: UIView {
         }
         
         isAccessibilityElement = false
+        accessibilityElementsHidden = true
     }
     
     func configure(with logoType: LogoType) {
@@ -75,7 +75,7 @@ final class TokensLogo: UIView {
             labelRenderer.isHidden = true
         case .label(let text, let tintColor):
             labelRenderer.setColor(tintColor, animated: false)
-            labelRenderer.setText(text)
+            labelRenderer.setText(text, ignoreVocalization: true)
             
             imageView.isHidden = true
             labelRenderer.isHidden = false

--- a/TwoFAS/TwoFAS/Root/Modules/Tokens/View/TokensViewController+Layout.swift
+++ b/TwoFAS/TwoFAS/Root/Modules/Tokens/View/TokensViewController+Layout.swift
@@ -96,9 +96,10 @@ extension TokensViewController {
             useNextToken: item.useNextToken,
             shouldAnimate: presenter.shouldAnimate
         )
+        cell?.accessibilityCustomActions = tokenActions(item)
         return cell
     }
-    
+
     func getHOTPCell(
         for collectionView: UICollectionView,
         indexPath: IndexPath,
@@ -125,6 +126,7 @@ extension TokensViewController {
             category: item.category,
             shouldAnimate: presenter.shouldAnimate
         )
+        cell?.accessibilityCustomActions = tokenActions(item)
         return cell
     }
     
@@ -221,6 +223,31 @@ extension TokensViewController {
         case .default: return .estimated(135)
         case .compact: return .absolute(90)
         }
+    }
+    
+    /// Returns some actions a user can do using *Voice Over*.
+    /// There are the same actions as the ones defined in the *context menu*.
+    private func tokenActions(_ token: TokenCell) -> [UIAccessibilityCustomAction] {
+        guard let serviceData = token.serviceData else { return [] }
+        return [
+            UIAccessibilityCustomAction(name: T.Commons.edit,
+                                        actionHandler: { (_: UIAccessibilityCustomAction) -> Bool in
+                                            self.presenter.handleEditService(serviceData)
+                                            return true
+                                        }),
+            
+            UIAccessibilityCustomAction(name: T.Tokens.copyToken,
+                                        actionHandler: { (_: UIAccessibilityCustomAction) -> Bool in
+                                            self.presenter.handleCopyToken(from: serviceData)
+                                            return true
+                                        }),
+            
+            UIAccessibilityCustomAction(name: T.Commons.delete,
+                                        actionHandler: { (_: UIAccessibilityCustomAction) -> Bool in
+                                            self.presenter.handleDeleteService(serviceData)
+                                            return true
+                                        })
+        ]
     }
 }
 


### PR DESCRIPTION
This pull request is related to the issue #91.

It brings two things:
- the image of the token is hidden from *Voice Over*: it does not bring any useful details and is decorative (03c072805de94a2a2290bb504d6d1e4826b6e3b1)
- accessibility custom actions have been added with the same actions as the context menu (992a5cb0f9ee7c214a2d2ceb459db02caecea87d)

To test this evolution:
- enable *Voice Over*
- in device settings, ensure that *Settings - Accessibility - VoiceOver - Verbosity - Actions* is defined to *Speak*
- then when on the cell, just listen the voice and swipe finger ginfer up or down to choose the action, then double tap to trigger it

More technical details can be found in [a11y-guidelines.orange.com/](https://a11y-guidelines.orange.com/en/mobile/ios/development/#custom-actions).

You can find in the attached ZIP a video of the evolution.

[91_add_VoiceOver_gestures.mov.zip](https://github.com/user-attachments/files/19030471/91_add_VoiceOver_gestures.mov.zip)
